### PR TITLE
Make it work with PHP 7

### DIFF
--- a/src/CliController.php
+++ b/src/CliController.php
@@ -26,7 +26,7 @@ class CliController {
                 $arguments->get('pass')
             );
             try {
-                call_user_method_array($command_handler, $this, []);
+                call_user_func_array(array($this, $command_handler), []);
             } catch (\PhpAmqpLib\Exception\AMQPProtocolChannelException $e) {
                 fwrite(STDERR, $e->getMessage()."\n");
                 exit(1);


### PR DESCRIPTION
Remove usage of call_user_func_array, since that's not available anymore in PHP 7