### PR TITLE
Always link to latest release

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ rmq-dump can be piped to another rmq-dump that allows copy messages qithout stor
 or use binary
 
 ```bash 
-curl -L https://github.com/webreactor/rmq-dump/releases/download/0.0.3/rmq-dump > /usr/local/bin/rmq-dump
+curl -L https://gitreleases.dev/gh/webreactor/rmq-dump/latest/rmq-dump > /usr/local/bin/rmq-dump
 chmod a+x /usr/local/bin/rmq-dump
 ```
 


### PR DESCRIPTION
Uses the gitreleases.dev service to not have to update the readme for every release